### PR TITLE
Fix icon symlinks

### DIFF
--- a/debian/thunderbird.links
+++ b/debian/thunderbird.links
@@ -1,6 +1,6 @@
 usr/lib/thunderbird/thunderbird usr/bin/thunderbird
-usr/lib/thunderbird/browser/chrome/icons/default/default16.png usr/share/icons/hicolor/16x16/apps/thunderbird.png
-usr/lib/thunderbird/browser/chrome/icons/default/default32.png usr/share/icons/hicolor/32x32/apps/thunderbird.png
-usr/lib/thunderbird/browser/chrome/icons/default/default48.png usr/share/icons/hicolor/48x48/apps/thunderbird.png
-usr/lib/thunderbird/browser/chrome/icons/default/default64.png usr/share/icons/hicolor/64x64/apps/thunderbird.png
-usr/lib/thunderbird/browser/chrome/icons/default/default128.png usr/share/icons/hicolor/128x128/apps/thunderbird.png
+usr/lib/thunderbird/chrome/icons/default/default16.png usr/share/icons/hicolor/16x16/apps/thunderbird.png
+usr/lib/thunderbird/chrome/icons/default/default32.png usr/share/icons/hicolor/32x32/apps/thunderbird.png
+usr/lib/thunderbird/chrome/icons/default/default48.png usr/share/icons/hicolor/48x48/apps/thunderbird.png
+usr/lib/thunderbird/chrome/icons/default/default64.png usr/share/icons/hicolor/64x64/apps/thunderbird.png
+usr/lib/thunderbird/chrome/icons/default/default128.png usr/share/icons/hicolor/128x128/apps/thunderbird.png


### PR DESCRIPTION
Should resolve https://github.com/pop-os/packaging-thunderbird/issues/1.

It seems due to caching Cosmic (or the relevant components) needs to be restarted to reflect the change. But after that this seems to work for me, in the launcher, app library, and the app list applet.